### PR TITLE
Add functionality to fetch user details

### DIFF
--- a/src/main/java/com/bakkcover/user/dtos/UserDetailResponse.java
+++ b/src/main/java/com/bakkcover/user/dtos/UserDetailResponse.java
@@ -1,33 +1,14 @@
 package com.bakkcover.user.dtos;
 
+import com.bakkcover.user.entities.User;
+
 public class UserDetailResponse {
-
-    private String firstName;
-    private String lastName;
-    private String email;
-
-    public String getFirstName() {
-        return firstName;
+    private User user;
+    public User getUser() {
+        return user;
     }
 
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
+    public void setUser(User user) {
+        this.user = user;
     }
-
-    public String getLastName() {
-        return lastName;
-    }
-
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
 }

--- a/src/main/java/com/bakkcover/user/entities/User.java
+++ b/src/main/java/com/bakkcover/user/entities/User.java
@@ -1,0 +1,69 @@
+package com.bakkcover.user.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    private String sub;
+
+    private String username;
+
+    private String email;
+
+    private String firstName;
+
+    private String lastName;
+
+    public User() { }
+    public User(String sub, String username, String email, String firstName, String lastName) {
+        this.sub = sub;
+        this.username = username;
+        this.email = email;
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public String getSub() {
+        return sub;
+    }
+
+    public void setSub(String sub) {
+        this.sub = sub;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/src/main/java/com/bakkcover/user/repositories/UserRepository.java
+++ b/src/main/java/com/bakkcover/user/repositories/UserRepository.java
@@ -1,0 +1,10 @@
+package com.bakkcover.user.repositories;
+
+import com.bakkcover.user.entities.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, String> {
+    Optional<User> findById(String id);
+}

--- a/src/main/java/com/bakkcover/user/services/UserService.java
+++ b/src/main/java/com/bakkcover/user/services/UserService.java
@@ -1,7 +1,11 @@
 package com.bakkcover.user.services;
 
+import com.bakkcover.user.entities.User;
+import com.bakkcover.user.exceptions.CustomException;
 import org.springframework.security.core.Authentication;
 
 public interface UserService {
     String getCognitoSub(Authentication authentication);
+
+    User getUser(Authentication authentication) throws CustomException;
 }

--- a/src/main/java/com/bakkcover/user/services/UserServiceImpl.java
+++ b/src/main/java/com/bakkcover/user/services/UserServiceImpl.java
@@ -1,12 +1,35 @@
 package com.bakkcover.user.services;
 
+import com.bakkcover.user.entities.User;
+import com.bakkcover.user.exceptions.CustomException;
+import com.bakkcover.user.repositories.UserRepository;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class UserServiceImpl implements UserService {
+    private final UserRepository userRepository;
+
+    public UserServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
     @Override
     public String getCognitoSub(Authentication authentication) {
         return authentication.getName();
+    }
+
+    @Override
+    public User getUser(Authentication authentication) throws CustomException {
+        String id = authentication.getName();
+        Optional<User> result = this.userRepository.findById(id);
+
+        if (result.isEmpty()) {
+            throw new CustomException("No user found!");
+        }
+
+        return result.get();
     }
 }


### PR DESCRIPTION
This pull-request adds the following:
* A table `users`
* An API endpoint to fetch user details

## A `users` table
This table has the following attributes:
* sub (PRIMARY KEY)
* username
* email
* first_name
* last_name

### Usage
When a user successfully signs up for a new account, two lambda functions will be triggered:
* [Pre sign-up Lambda trigger](https://github.com/Bakkcover/lambda-bakkcover-cognito-autoConfirmUser)
   * Automatically confirms the user.
* [Post confirmation Lambda trigger](https://github.com/Bakkcover/lambda-bakkcover-cognito-addUserToRds)
   * When the user is confirmed, adds an entry to the `users` table with the following attributes:
      * sub
      * username
      * email
    * Note: the remaining two attributes ("first_name" and "last_name") are left empty at this point; the user can insert/update these fields through the "My Account" page (or a similar section) on the frontend.
       * this feature is not yet implemented.

## An API endpoint to fetch user details
### Endpoint
`GET`: `/api/users/detail`

### Response Body
```json
{
    "user": {
        "sub": "9da3a0d0-537a-4315-ad6b-90d897c7d63c",
        "username": "test1",
        "email": "test1@example.com",
        "firstName": null,
        "lastName": null
    }
}
```

### Brief Description
The attribute "sub" is extracted from the JWT provided by the user in the `GET` request.

An entry with a matching "sub" attribute from the `users` table is then returned.